### PR TITLE
[7.0][FIX] binary_field: the log done in JS makes unusable some views if the field has no value defined

### DIFF
--- a/binary_field/static/src/js/widget.js
+++ b/binary_field/static/src/js/widget.js
@@ -50,7 +50,6 @@ openerp.binary_field = function (instance) {
 
     instance.web_kanban.KanbanRecord.include({
         kanban_image: function(model, field, id, cache, options) {
-            console.log(this.record[field].value)
             if (this.record[field]
                 && this.record[field].value
                 && instance.web.form.is_url(this.record[field].value)


### PR DESCRIPTION
This happens for instance when opening the standard product kanban view
if there is no 'image_small' value (for instance if the binary could not get
downloaded from a remote filestore).